### PR TITLE
use port 8080

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	log.SetLevel(log.DebugLevel)
 	log.Printf("Starting server")
-	api.StartHTTPApi(dp, nil, 0, 0, "127.0.0.1:8888")
+	api.StartHTTPApi(dp, nil, 0, 0, "127.0.0.1:8080")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module external-dns-openstack-webhook
 
-go 1.23
+go 1.23.3
+
 toolchain go1.23.4
 
 require (


### PR DESCRIPTION
it's the default in the helm chart
https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/templates/deployment.yaml\#L169