### PR TITLE
change default Docker user to 1000

### DIFF
--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -7,4 +7,5 @@ ENV HOME=/
 ENV OS_CLIENT_CONFIG_FILE=/etc/openstack/clouds.yaml
 ENV OS_CLOUD=openstack
 COPY external-dns-openstack-webhook /external-dns-openstack-webhook
+USER 1000
 ENTRYPOINT ["/external-dns-openstack-webhook"]


### PR DESCRIPTION
This ensures that the user is unprivileged and makes it easier to comply with PodSecurityStandards or similar mechanisms.