### PR TITLE
fix: only exclude zones with DELETED status from the list

### DIFF
--- a/internal/designate/provider/provider.go
+++ b/internal/designate/provider/provider.go
@@ -94,7 +94,7 @@ func (p designateProvider) getZones(ctx context.Context) (map[string]string, err
 
 	err := p.client.ForEachZone(ctx,
 		func(zone *zones.Zone) error {
-			if zone.Type != "" && strings.ToUpper(zone.Type) != "PRIMARY" || zone.Status != "ACTIVE" {
+			if zone.Type != "" && strings.ToUpper(zone.Type) != "PRIMARY" || zone.Status == "DELETE" {
 				return nil
 			}
 


### PR DESCRIPTION
Filtering zones on only the ACTIVE status, causes the list of zones to change. Especially the PENDING status is used by Designate during reconciliation processes.

Fixes: #33