### PR TITLE
improve installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This projects externalizes the in-tree [OpenStack Designate provider](https://gi
 
 ## Installation
 
-This webhook provider is run easiest as sidecar within the `external-dns` pod. This can be achieved using the official
-`external-dns` Helm chart and [its support for the `webhook` provider type]([https://kubernetes-sigs.github.io/external-dns/latest/charts/external-dns/#providers]).
+This webhook provider is run easiest as sidecar within the `external-dns` pod. This can be achieved using the 
+[official `external-dns` Helm chart](https://kubernetes-sigs.github.io/external-dns/latest/charts/external-dns/)
+and [its support for the `webhook` provider type]([https://kubernetes-sigs.github.io/external-dns/latest/charts/external-dns/#providers]).
 
 Setting the `provider.name` to `webhook` allows configuration of the
 `external-dns-openstack-webhook` via a few additional values:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ extraVolumes:
       secretName: oscloudsyaml
 ```
 
-The referenced `extraVolumeMount` points to a `Secret` containing the `clouds.yaml` file, which provides the OpenStack Keystone credentials to the webhook provider. While it seems cumbersome to require a file instead of the commonly used `OS_*` environment variables, the use of a `clouds.yaml` file offers more structure, capabilities and allows for better validation.
+The referenced `extraVolumeMount` points to a `Secret` containing a [`clouds.yaml` file](https://docs.openstack.org/python-openstackclient/latest/configuration/index.html#clouds-yaml),
+which provides the OpenStack Keystone credentials to the webhook provider.
+`OS_*` environment variables are not supported for configuration, since the use of a `clouds.yaml` file offers more structure, capabilities and allows for better validation.
+The one exception to this is `OS_CLOUD` for setting the name of the cloud in `clouds.yaml` to use.
 
-The following example is a basic example of such a file, using `openstack` as the cloud name (which is the default used by this webhook):
+The following example is a basic example of a `clouds.yaml` file, using `openstack` as the cloud name (the default used by this webhook):
 
 ```yaml
 clouds:
@@ -58,7 +61,8 @@ In such cases, please raise a GitHub issue with as much detail as possible. PRs 
 
 ## Development
 
-To run the webhook locally, you'll also require a [clouds.yaml](https://docs.openstack.org/python-openstackclient/pike/configuration/index.html#clouds-yaml) file in one of the standard-locations. Also the name of the entry to be used has be given via `OS_CLOUD` environment variable.
+To run the webhook locally, you'll also require a [clouds.yaml](https://docs.openstack.org/python-openstackclient/pike/configuration/index.html#clouds-yaml) file in one of the standard-locations.
+Also the name of the entry to be used has be given via `OS_CLOUD` environment variable.
 You can then start the webhook server using:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ provider:
       - name: oscloudsyaml
         mountPath: /etc/openstack/
     resources: {}
-    securityContext:
-      runAsUser: 1000
 ```
 
 The referenced `extraVolumeMount` points to a `Secret` containing the `clouds.yaml` file, which provides the OpenStack Keystone credentials to the webhook provider. While it seems cumbersome to require a file instead of the commonly used `OS_*` environment variables, the use of a `clouds.yaml` file offers more structure, capabilities and allows for better validation.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ provider:
       - name: oscloudsyaml
         mountPath: /etc/openstack/
     resources: {}
+extraVolumes:
+  - name: oscloudsyaml
+    secret:
+      secretName: oscloudsyaml
 ```
 
 The referenced `extraVolumeMount` points to a `Secret` containing the `clouds.yaml` file, which provides the OpenStack Keystone credentials to the webhook provider. While it seems cumbersome to require a file instead of the commonly used `OS_*` environment variables, the use of a `clouds.yaml` file offers more structure, capabilities and allows for better validation.
@@ -45,15 +49,6 @@ An existing file can be converted into a Secret via kubectl:
 
 ```shell
 kubectl create secret generic oscloudsyaml --namespace external-dns --from-file=clouds.yaml
-```
-
-and then also be added an extraVolume to within the `values.yaml` of external-dns:
-
-```yaml
-extraVolumes:
-  - name: oscloudsyaml
-    secret:
-      secretName: oscloudsyaml
 ```
 
 ## Bugs or feature requests


### PR DESCRIPTION
* remove securityContext from sample config
  the default user has been set accordingly in #43
* add a direct link to the Helm Chart documentation where I would expect it (it is counterintuitive in my opinion, to click on the provider-link to get to the Helm Chart docs).
* merge the two `values.yaml` examples, since they only work together. This makes the doc easier to follow and copy-paste from IMHO
* add a link to the openstack configuration documentation
* clearly state that OS_* variables are not supported and document the exception of OS_CLOUD being supported
* reformatting